### PR TITLE
Pass custom styles to the WebView container

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,8 @@ export default App
 | callback | False    | A function that you want the SDK to callback to upon closing of the SDK (whether successful or failed) |
 | version  | False    | Which version of the LinkSDK you want to load (defaults to @latest)                                    |
 | sandbox  | False    | Whether the LinkSDK is in sandbox or not (defaults to `False`)                                         |
+| containerStyle  | False    | Custom styles passed to the opened container                                                    |
+| containerClosedStyle  | False    | Custom styles passed to the closed container                                              |
 
 
 ## Methods

--- a/src/components/LinkSDK/index.js
+++ b/src/components/LinkSDK/index.js
@@ -179,9 +179,12 @@ const LinkSDK = forwardRef((props, ref) => {
         }
     }
 
+    const openedContainerStyle = [styles.container, props.containerStyle];
+    const closedContainerStyle = [styles.containerClosed, props.containerClosedStyle];
+
     return (
         <View
-            style={isOpen ? styles.container : styles.containerClosed}
+            style={isOpen ? openedContainerStyle : closedContainerStyle}
             height={Dimensions.get('window').height}
             width={Dimensions.get('window').width}
         >
@@ -209,7 +212,9 @@ const LinkSDK = forwardRef((props, ref) => {
 })
 
 LinkSDK.defaultProps = {
-  webViewProps: {}
+  webViewProps: {},
+  containerStyle: {},
+  containerClosedStyle: {}
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Allow custom styles being passed to the container of WebView.

Solves: https://github.com/leantechnologies/link-sdk-react-native/issues/25