### PR TITLE
FEN-485: Fix `pod install` for v3

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.linkreactnative">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lean-react-native",
-  "version": "3.0.3",
+  "version": "3.0.4-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lean-react-native",
-      "version": "3.0.3",
+      "version": "3.0.4-beta.1",
       "license": "ISC",
       "dependencies": {
         "react": "18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lean-react-native",
-  "version": "3.0.4-beta.1",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lean-react-native",
-      "version": "3.0.4-beta.1",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "src/components/LinkSDK/index.js",
   "name": "lean-react-native",
-  "version": "3.0.3",
+  "version": "3.0.4-beta.1",
   "description": "A React Native wrapper for Lean's LinkSDK",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "src/components/LinkSDK/index.js",
   "name": "lean-react-native",
-  "version": "3.0.4-beta.1",
+  "version": "3.0.4",
   "description": "A React Native wrapper for Lean's LinkSDK",
   "repository": {
     "type": "git",

--- a/src/components/LinkSDK/LeanWebClient.js
+++ b/src/components/LinkSDK/LeanWebClient.js
@@ -34,7 +34,7 @@ class LeanWebClient {
   static handleOverrideUrlLoading(request, callback) {
     Logger.info('handleOverrideUrlLoading', request.url);
 
-    if (request.url.startsWith('file://')) {
+    if (request.url.startsWith('file://') || request.url === 'about:blank') {
       return false;
     }
 


### PR DESCRIPTION
Our v3 SDK was missing a package name definition in AndroidManifest.xml, this was causing an error when a user ran `pod install` for ios in a RN project.

1. This PR fixes that by adding the package name.
2. It also includes a minor cleanup for a warning which is thrown when starting the SDK. iOS starts out with `about:blank` and we just needed to ignore this URL.