### PR TITLE
FEN-626: Fix Android webview-client to listen for URL redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lean-react-native",
-  "version": "3.0.7-alpha.3",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lean-react-native",
-      "version": "3.0.7-alpha.3",
+      "version": "3.0.7",
       "dependencies": {
         "react-native-url-polyfill": "^1.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "src/components/LinkSDK/index.js",
   "name": "lean-react-native",
-  "version": "3.0.7-alpha.3",
+  "version": "3.0.7",
   "description": "A React Native wrapper for Lean's LinkSDK",
   "repository": {
     "type": "git",

--- a/src/components/LinkSDK/LeanWebClient.js
+++ b/src/components/LinkSDK/LeanWebClient.js
@@ -33,17 +33,15 @@ class LeanWebClient {
       },
     };
   }
-  
-  
-  
-  static handleOverrideUrlLoading(request, callback) {
-    Logger.info('handleOverrideUrlLoading', request.url);
 
-    if (request.url.startsWith('file://') || request.url === 'about:blank') {
+  static handleOverrideUrlLoading(event, callback) {
+    Logger.info('handleOverrideUrlLoading', event.url);
+
+    if (event.url.startsWith('file://') || event.url === 'about:blank') {
       return false;
     }
 
-    if (request.url.includes('https://cdn.leantech.me/link/loader')) {
+    if (event.url.includes('https://cdn.leantech.me/link/loader')) {
       return true;
     }
 
@@ -52,7 +50,7 @@ class LeanWebClient {
       this.responseListener = callback;
     }
 
-    const urlObject = new URL(request.url);
+    const urlObject = new URL(event.url);
 
     /**
      * Standard redirect URI from hosted HTML has three parts
@@ -83,14 +81,14 @@ class LeanWebClient {
       }
 
       // Send response back caller for proper handling
-      this.onRedirectResponse(this.getResponseFromParams(request.url));
+      this.onRedirectResponse(this.getResponseFromParams(event.url));
 
       // Do not override URL loading
       return false;
     }
 
     // Open all URLs in default web browser
-    Linking.openURL(request.url);
+    Linking.openURL(event.url);
 
     // Do not override URL loading
     return false;

--- a/src/components/LinkSDK/index.js
+++ b/src/components/LinkSDK/index.js
@@ -70,12 +70,13 @@ const LinkSDK = forwardRef((props, ref) => {
         originWhitelist={['*']}
         source={{uri: initializationURL}}
         allowsInlineMediaPlayback={true}
+        setSupportMultipleWindows={false}
         mediaPlaybackRequiresUserAction={false}
-        onShouldStartLoadWithRequest={request =>
-          LeanWebClient.handleOverrideUrlLoading(
-            request,
-            responseCallbackHandler,
-          )
+        onShouldStartLoadWithRequest={event =>
+          LeanWebClient.handleOverrideUrlLoading(event, responseCallbackHandler)
+        }
+        onNavigationStateChange={event =>
+          LeanWebClient.handleOverrideUrlLoading(event, responseCallbackHandler)
         }
         cacheEnabled={false}
         javaScriptEnabledAndroid={true}


### PR DESCRIPTION
[FEN-626]

This PR includes a change to:
1. Add a new listener method (`onNavigationStateChange`) to listen for new URL redirects in Android. The existing method —onShouldStartLoadWithRequest—is not called on Android, hence the issue with the callback not being fired and the webview remaining in view though transparent. This doesn't affect iOS.
2. Set `setSupportMultipleWindows` to `false` to allow the newly added method to be fired. Security considerations around setting `setSupportMultipleWindows` to `false` were considered in this implementation, and we don't have any exposure as a result.
3. Improved parameter naming for `LeanWebClient` to make the code more readable (`response -> event`).

[FEN-626]: https://leantechnologies.atlassian.net/browse/FEN-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ