### PR TITLE
FEN-801: add event listener for window open to handle redirects in iOS

### DIFF
--- a/src/components/LinkSDK/index.js
+++ b/src/components/LinkSDK/index.js
@@ -78,6 +78,15 @@ const LinkSDK = forwardRef((props, ref) => {
         onNavigationStateChange={event =>
           LeanWebClient.handleOverrideUrlLoading(event, responseCallbackHandler)
         }
+        onOpenWindow={syntheticEvent => {
+          // This is required to manage iOS window.open events.
+          // We don't get onNavigationStateChange or onShouldStartLoadWithRequest in iOS for this particular event.
+          const {nativeEvent} = syntheticEvent;
+          return LeanWebClient.handleOverrideUrlLoading(
+            {url: nativeEvent.targetUrl},
+            responseCallbackHandler,
+          );
+        }}
         cacheEnabled={false}
         javaScriptEnabledAndroid={true}
         javaScriptCanOpenWindowsAutomatically


### PR DESCRIPTION
[FEN-801]

After 2 days of research and debugging, I finally found a way to handle this issue for iOS.

**Context:**
When using `window.open(url, "_self")` inside a React Native WebView, iOS behaves differently than Android because:
* iOS WebView (WKWebView) restricts `window.open` with `_self`
Unlike Android, iOS does not allow replacing the current page using `window.open(url, "_self")`.
* iOS may not trigger `onNavigationStateChange` or `onShouldStartLoadWithRequest`
Since `window.open("_self")` is blocked, the WebView does not detect the URL change.

**Initial solution**
I initially made a change in v1 and v2 which was supposed to fix it, but after a lot of testing, I had to find a different solution as the initial fix didn't work. Both PRs are closed now.
v1 - https://github.com/leantechnologies/link-sdk-web/pull/919
v2 - https://github.com/leantechnologies/link-sdk-web-v2/pull/341

**New solution**
The new solution is to add `onOpenWindow` listener to `react-native-webview` and call our url override handler from there. This allows us to handle redirects properly for iOS users on ReactNative.

[FEN-801]: https://leantechnologies.atlassian.net/browse/FEN-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ