### PR TITLE
CX-1734: parse redirect URL params on OpenBanking redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lean-react-native",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lean-react-native",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "dependencies": {
         "react-native-url-polyfill": "^1.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/components/LinkSDK/index.js",
   "types": "dist/src/components/LinkSDK/index.d.ts",
   "name": "lean-react-native",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "files": [
     "dist/"
   ],

--- a/src/components/LinkSDK/LeanWebClient.ts
+++ b/src/components/LinkSDK/LeanWebClient.ts
@@ -9,7 +9,8 @@ interface NavigationEvent {
 }
 
 class LeanWebClient {
-  static responseListener: ((response: LeanCallbackResponse) => void) | null = null;
+  static responseListener: ((response: LeanCallbackResponse) => void) | null =
+    null;
 
   static onPageStarted(): void {
     Logger.info('SDK initialization started');
@@ -35,7 +36,8 @@ class LeanWebClient {
       secondary_status: urlParams.get('secondary_status'),
       bank: {
         bank_identifier: urlParams.get('bank_identifier'),
-        is_supported: urlParams.get('bank_is_supported')?.toLowerCase() === 'true',
+        is_supported:
+          urlParams.get('bank_is_supported')?.toLowerCase() === 'true',
       },
     };
   }
@@ -70,20 +72,11 @@ class LeanWebClient {
     if (urlObject.protocol === 'leanlink:') {
       // Close SDK if it's an internal OpenBanking redirect
       if (urlObject.hostname === 'redirect') {
+        const response = this.getResponseFromParams(event.url);
         this.onRedirectResponse({
+          ...response,
           status: 'SUCCESS',
           message: 'Link closed after redirect',
-          last_api_response: null,
-          exit_point: null,
-          exit_intent_point: null,
-          exit_survey_reason: null,
-          user_exit_intent: null,
-          lean_correlation_id: null,
-          secondary_status: null,
-          bank: {
-            bank_identifier: null,
-            is_supported: false,
-          },
         });
 
         // Do not override URL loading


### PR DESCRIPTION
## Summary
- Previously, the `leanlink://redirect` case in `handleOverrideUrlLoading` hardcoded all `LeanCallbackResponse` fields to `null`/`false`, discarding any data carried in the redirect URL params
- Now calls `getResponseFromParams` and spreads the parsed response, only overriding `status` and `message` as intended